### PR TITLE
Fix usage of both --env/--file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ A solution to this problem is to only use the secret within the `RUN` instructio
 
 ```Dockerfile
 # Install github-token-helper
-RUN curl -LO https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper && \
-    chmod +x ./github-token-helper && \
-    git config --global credential.https://github.com.helper "$(pwd)/github-token-helper -f /run/secrets/github_token"
+RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper -o $HOME/.github-token-helper && \
+    chmod +x $HOME/.github-token-helper && \
+    git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token"
 
 # Private repo
 RUN --mount=type=secret,id=github_token \
@@ -52,9 +52,9 @@ RUN --mount=type=secret,id=github_token \
 The basic installation requires the script to present on your system and registered as a [custom helper](https://git-scm.com/docs/gitcredentials#_custom_helpers):
 
 ```bash
-curl -LO https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper
-chmod +x ./github-token-helper
-git config --global credential.https://github.com.helper "$(pwd)/github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
+curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper -o $HOME/.github-token-helper
+chmod +x $HOME/github-token-helper
+git config --global credential.https://github.com.helper "$HOME/github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A solution to this problem is to only use the secret within the `RUN` instructio
 
 ```Dockerfile
 # Install github-token-helper
-RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper -o $HOME/.github-token-helper && \
+RUN curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.1/github-token-helper -o $HOME/.github-token-helper && \
     chmod +x $HOME/.github-token-helper && \
     git config --global credential.https://github.com.helper "$HOME/.github-token-helper -f /run/secrets/github_token"
 
@@ -52,7 +52,7 @@ RUN --mount=type=secret,id=github_token \
 The basic installation requires the script to present on your system and registered as a [custom helper](https://git-scm.com/docs/gitcredentials#_custom_helpers):
 
 ```bash
-curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.0/github-token-helper -o $HOME/.github-token-helper
+curl -L https://raw.githubusercontent.com/beacon-biosignals/github-token-helper/v0.1.1/github-token-helper -o $HOME/.github-token-helper
 chmod +x $HOME/github-token-helper
 git config --global credential.https://github.com.helper "$HOME/github-token-helper -f /run/secrets/github_token -e GITHUB_TOKEN"
 ```

--- a/github-token-helper
+++ b/github-token-helper
@@ -35,7 +35,7 @@ set -- "${args[@]}"  # restore unhandled parameters
 if [ -z "$token_file" ] && [ -z "$token_var" ]; then
     echo "Either --env/--file must be specified" >&2
     exit 1
-elif [ -n "$token_file" ] && [ ! -f "$token_file" ]; then
+elif [ -n "$token_file" ] && [ -z "$token_var" ] && [ ! -f "$token_file" ]; then
     echo "Specified GitHub token file does not exist: $token_file" >&2
     exit 1
 fi
@@ -62,9 +62,14 @@ done < /dev/stdin
 if [ "$1" == "get" ] && [ "$is_match" == true ]; then
     # Read password information at the last second to avoid loading into memory
     # when we don't need it.
+
+    # Prefer using the contents of `token_var` if it is set
     if [ -n "$token_var" ]; then
         password="${!token_var}"
-    else
+    fi
+
+    # Use the token file if it exists
+    if [ -z "$password" ] && [ -f "$token_file" ]; then
         password="$(cat $token_file)"
     fi
 


### PR DESCRIPTION
When using both `--env`/`--file` only the contents from `--env` was ever being used. Also, if using both
and the specified `--file` did not exist the script would fail.