### PR TITLE
Allow specifying alternative GH token sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ git config --global credential.https://github.com.helper "$HOME/.github-token-he
 
 The `github-token-helper` accepts the following options:
 
-- `--file` / `-f`: Specify a file containing the PAT. Used with `docker build --secret`.
-- `--env` / `-e`: The name of an environmental variable which contains the PAT to use. Should not be used with Docker's `--build-arg` to avoid credential leaking but can be useful for running the container interactively.
+- `--file` / `-f`: Specify the file(s) containing the PAT. Used with `docker build --secret`.
+- `--env` / `-e`: The name of the environmental variable(s) which contains the PAT to use. Should not be used with Docker's `--build-arg` to avoid credential leaking but can be useful for running the container interactively.
 
 ## Testing
 

--- a/github-token-helper
+++ b/github-token-helper
@@ -9,17 +9,19 @@ host=github.com  # Only the hostname, no path
 username=git
 
 args=()
+token_files=()
+token_vars=()
 while [[ $# -gt 0 ]]; do
   flag="$1"
 
   case $flag in
     -f|--file)
-      token_file="$2"
+      token_files+=("$2")
       shift # remove flag
       shift # remove value
       ;;
     -e|--env)
-      token_var="$2"
+      token_vars+=("$2")
       shift # remove flag
       shift # remove value
       ;;
@@ -32,11 +34,8 @@ done
 
 set -- "${args[@]}"  # restore unhandled parameters
 
-if [ -z "$token_file" ] && [ -z "$token_var" ]; then
+if [ "${#token_files[@]}" -eq 0 ] && [ "${#token_vars[@]}" -eq 0 ]; then
     echo "Either --env/--file must be specified" >&2
-    exit 1
-elif [ -n "$token_file" ] && [ -z "$token_var" ] && [ ! -f "$token_file" ]; then
-    echo "Specified GitHub token file does not exist: $token_file" >&2
     exit 1
 fi
 
@@ -63,14 +62,20 @@ if [ "$1" == "get" ] && [ "$is_match" == true ]; then
     # Read password information at the last second to avoid loading into memory
     # when we don't need it.
 
-    # Prefer using the contents of `token_var` if it is set
-    if [ -n "$token_var" ]; then
+    # Prefer using the contents of a `token_var` if one is set
+    for token_var in "${token_vars[@]}"; do
         password="${!token_var}"
-    fi
+        [ -n "$password" ] && break
+    done
 
-    # Use the token file if it exists
-    if [ -z "$password" ] && [ -f "$token_file" ]; then
-        password="$(cat $token_file)"
+    # Fallback on using the first token file that exists
+    if [ -z "$password" ]; then
+        for token_file in "${token_files[@]}"; do
+            if [ -f "$token_file" ]; then
+                password="$(cat $token_file)"
+                break
+            fi
+        done
     fi
 
     if [ -n "$password" ]; then
@@ -78,5 +83,8 @@ if [ "$1" == "get" ] && [ "$is_match" == true ]; then
         echo "host=${host}"
         echo "username=${username}"
         echo "password=${password}"
+    else
+        echo "Specified GitHub token(s) could not be found" >&2
+        exit 1
     fi
 fi


### PR DESCRIPTION
Allows end users to specify multiple environmental variables or files to use as the source of the GitHub token. This allows for the use of multiple files to be specified and use the first file that is defined as the token.

Would be nice to process the `--env` and `--file` arguments in the order in which they were passed in but that would be a breaking change which we can do at a later time.